### PR TITLE
PGL-13: fix icc-connector pom

### DIFF
--- a/pegelhub-icc-connector/pom.xml
+++ b/pegelhub-icc-connector/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.stm.pegelhub</groupId>
-    <artifactId>pegelhub-core</artifactId>
+    <artifactId>pegelhub-icc-connector</artifactId>
     <version>2022.01</version>
 
     <properties>
@@ -42,5 +42,34 @@
             <version>${logback.version}</version>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.stm.pegelhub.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
The built ICC-Connector JAR file was not executable because the POM missed some plugins. The artifact ID was also incorrect.